### PR TITLE
After updating RVC in the rvc_server repo, the method signature for i…

### DIFF
--- a/command_line_interface.py
+++ b/command_line_interface.py
@@ -29,7 +29,7 @@ sys.argv = ['', '--commandlinemode']
 infer_web = __import__('infer-web')
 
 # Load the model
-_ = infer_web.get_vc(args.voice)
+_ = infer_web.get_vc(args.voice, None, None)
 
 # Perform inference
 _, (output_samplerate, audio_output) = infer_web.vc_single(args.sid,


### PR DESCRIPTION
…nfer_web.get_vc now requires three arguments, so I have updated the call site.